### PR TITLE
refactor: Use `onMounted` to avoid `Suspense`s being used by Vue

### DIFF
--- a/app/src/views/MonitorView.vue
+++ b/app/src/views/MonitorView.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, onUnmounted } from 'vue'
+import { ref, inject, onUnmounted, onMounted } from 'vue'
 import type { VueCookies } from 'vue-cookies'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -189,5 +189,5 @@ async function syncMonitor() {
   setTimeout(async () => await syncMonitor(), ONE_MINUTE_MS)
 }
 
-await syncMonitor()
+onMounted(syncMonitor)
 </script>

--- a/app/src/views/MonitorsView.vue
+++ b/app/src/views/MonitorsView.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, onUnmounted } from 'vue'
+import { ref, inject, onUnmounted, onMounted } from 'vue'
 import type { VueCookies } from 'vue-cookies'
 
 import ApiAlert from '@/components/ApiAlert.vue'
@@ -103,5 +103,5 @@ async function syncMonitors() {
   setTimeout(async () => await syncMonitors(), FIVE_MINUTES_MS)
 }
 
-await syncMonitors()
+onMounted(syncMonitors)
 </script>


### PR DESCRIPTION
Fixes the failing test seen in https://github.com/cron-mon-io/cron-mon-app/pull/31, which is introduced by the newer version of Vuetify - though in truth this was our fault since there's been a warning in the logs for a little while about using Suspense since it's still experimental. This also fixes those warning because we put the async stuff that was being called in setup directly into `onMounted`.