### PR TITLE
Fix/alert config summaries

### DIFF
--- a/app/src/repos/__tests__/alert-config-repo.spec.ts
+++ b/app/src/repos/__tests__/alert-config-repo.spec.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeAll, describe, it, expect } from 'vitest'
 import { HttpResponse, http } from 'msw'
 
 import { AlertConfigRepository } from '@/repos/alert-config-repo'
-import type { AlertConfigSummary } from '@/types/alert-config'
+import type { BasicAlertConfig } from '@/types/alert-config'
 
 import { setupTestAPI } from '@/utils/testing/test-api'
 
@@ -97,7 +97,7 @@ describe('AlertConfigRepository', () => {
   })
 
   it('addMonitor', async () => {
-    const newAlertConfig: AlertConfigSummary = {
+    const newAlertConfig: BasicAlertConfig = {
       name: 'New config',
       active: true,
       on_late: true,

--- a/app/src/repos/__tests__/alert-config-repo.spec.ts
+++ b/app/src/repos/__tests__/alert-config-repo.spec.ts
@@ -26,16 +26,7 @@ describe('AlertConfigRepository', () => {
       {
         active: true,
         alert_config_id: 'eef240ae-a5b3-4971-b3c3-2603434d1ede',
-        monitors: [
-          {
-            monitor_id: 'cfe88463-5c04-4b43-b10f-1f508963cc5d',
-            name: 'foo-backup.sh'
-          },
-          {
-            monitor_id: 'e534a01a-4efe-4b8e-9b04-44a3c76b0462',
-            name: 'analyse-bar.py'
-          }
-        ],
+        monitors: 2,
         name: 'Slack on late',
         on_error: false,
         on_late: true,

--- a/app/src/repos/alert-config-repo.ts
+++ b/app/src/repos/alert-config-repo.ts
@@ -1,12 +1,13 @@
 import type {
   AlertConfig,
   AlertConfigIdentity,
+  AlertConfigSummary,
   BasicAlertConfig
 } from '@/types/alert-config'
 import { ApiRepository } from './api-repo'
 
 export interface AlertConfigRepoInterface {
-  getAlertConfigs(): Promise<Array<AlertConfig>>
+  getAlertConfigs(): Promise<Array<AlertConfigSummary>>
   getAlertConfig(alertConfigId: string): Promise<AlertConfig>
   addAlertConfig(alertConfig: AlertConfig): Promise<AlertConfig>
   updateAlertConfig(alertConfig: AlertConfig): Promise<AlertConfig>
@@ -18,14 +19,14 @@ type AlertConfigResp = {
 }
 
 type AlertConfigList = {
-  data: Array<AlertConfig>
+  data: Array<AlertConfigSummary>
   paging: {
     total: number
   }
 }
 
 export class AlertConfigRepository extends ApiRepository implements AlertConfigRepoInterface {
-  async getAlertConfigs(): Promise<Array<AlertConfig>> {
+  async getAlertConfigs(): Promise<Array<AlertConfigSummary>> {
     const resp = await this.sendRequest(`/api/v1/alert-configs`, 'GET')
     return (resp as AlertConfigList).data
   }

--- a/app/src/repos/alert-config-repo.ts
+++ b/app/src/repos/alert-config-repo.ts
@@ -1,4 +1,8 @@
-import type { AlertConfig, AlertConfigSummary, AlertConfigIdentity } from '@/types/alert-config'
+import type {
+  AlertConfig,
+  AlertConfigIdentity,
+  BasicAlertConfig
+} from '@/types/alert-config'
 import { ApiRepository } from './api-repo'
 
 export interface AlertConfigRepoInterface {
@@ -31,7 +35,7 @@ export class AlertConfigRepository extends ApiRepository implements AlertConfigR
     return (resp as AlertConfigResp).data
   }
 
-  async addAlertConfig(alertConfig: AlertConfigSummary): Promise<AlertConfig> {
+  async addAlertConfig(alertConfig: BasicAlertConfig): Promise<AlertConfig> {
     return await this.postAlertConfigInfo(`/api/v1/alert-configs`, 'POST', alertConfig)
   }
 
@@ -50,7 +54,7 @@ export class AlertConfigRepository extends ApiRepository implements AlertConfigR
   private async postAlertConfigInfo(
     route: string,
     method: string,
-    alertConfig: AlertConfigSummary
+    alertConfig: BasicAlertConfig
   ): Promise<AlertConfig> {
     const resp = await this.sendRequest(route, method, {
       name: alertConfig.name,

--- a/app/src/types/alert-config.ts
+++ b/app/src/types/alert-config.ts
@@ -1,4 +1,4 @@
-export type AlertConfigSummary = {
+export type BasicAlertConfig = {
   name: string
   active: boolean
   on_late: boolean
@@ -6,7 +6,7 @@ export type AlertConfigSummary = {
   type: SlackAlertType
 }
 
-export type AlertConfigIdentity = AlertConfigSummary & {
+export type AlertConfigIdentity = BasicAlertConfig & {
   alert_config_id: string
 }
 

--- a/app/src/types/alert-config.ts
+++ b/app/src/types/alert-config.ts
@@ -10,6 +10,10 @@ export type AlertConfigIdentity = BasicAlertConfig & {
   alert_config_id: string
 }
 
+export type AlertConfigSummary = AlertConfigIdentity & {
+  monitors: number
+}
+
 export type AlertConfig = AlertConfigIdentity & {
   monitors: Array<{
     monitor_id: string

--- a/app/src/utils/testing/test-api.ts
+++ b/app/src/utils/testing/test-api.ts
@@ -379,7 +379,17 @@ export function setupTestAPI(expectedToken: string): SetupServer {
         return (
           assertAuth(request) ||
           HttpResponse.json({
-            data: alertConfigs,
+            data: alertConfigs.map((ac) => {
+              return {
+                alert_config_id: ac.alert_config_id,
+                name: ac.name,
+                active: ac.active,
+                on_late: ac.on_late,
+                on_error: ac.on_error,
+                type: ac.type,
+                monitors: ac.monitors.length
+              }
+            }),
             paging: { total: alertConfigs.length }
           })
         )

--- a/app/src/utils/testing/test-api.ts
+++ b/app/src/utils/testing/test-api.ts
@@ -4,7 +4,7 @@ import { HttpResponse, http, type StrictRequest, type JsonBodyType } from 'msw'
 import { v4 as uuidv4 } from 'uuid'
 
 import type { MonitorSummary } from '@/types/monitor'
-import type { AlertConfigSummary } from '@/types/alert-config'
+import type { BasicAlertConfig } from '@/types/alert-config'
 
 export function setupTestAPI(expectedToken: string): SetupServer {
   let monitors = [
@@ -416,7 +416,7 @@ export function setupTestAPI(expectedToken: string): SetupServer {
           return authErroResponse
         }
 
-        const body = (await request.json()) as AlertConfigSummary
+        const body = (await request.json()) as BasicAlertConfig
         const alertConfig = {
           alert_config_id: uuidv4(),
           name: body.name,
@@ -454,7 +454,7 @@ export function setupTestAPI(expectedToken: string): SetupServer {
           )
         }
 
-        const body = (await request.json()) as AlertConfigSummary
+        const body = (await request.json()) as BasicAlertConfig
 
         return HttpResponse.json({
           data: {


### PR DESCRIPTION
The `monitors` attribute in the response from `GET /api/v1/alert-configs` is just a number representing the number of monitors using that alert config, as opposed to the name and ID of each monitor that's using it.