### PR TITLE
feat: Add `AlertConfigService`

### DIFF
--- a/app/src/repos/alert-config-repo.ts
+++ b/app/src/repos/alert-config-repo.ts
@@ -4,7 +4,7 @@ import type {
   AlertConfigSummary,
   BasicAlertConfig
 } from '@/types/alert-config'
-import { ApiRepository } from './api-repo'
+import { ApiClient } from '@/utils/client'
 
 export interface AlertConfigRepoInterface {
   getAlertConfigs(): Promise<Array<AlertConfigSummary>>
@@ -25,7 +25,7 @@ type AlertConfigList = {
   }
 }
 
-export class AlertConfigRepository extends ApiRepository implements AlertConfigRepoInterface {
+export class AlertConfigRepository extends ApiClient implements AlertConfigRepoInterface {
   async getAlertConfigs(): Promise<Array<AlertConfigSummary>> {
     const resp = await this.sendRequest(`/api/v1/alert-configs`, 'GET')
     return (resp as AlertConfigList).data

--- a/app/src/repos/api-key-repo.ts
+++ b/app/src/repos/api-key-repo.ts
@@ -1,5 +1,5 @@
 import type { ApiKey } from '@/types/api-key'
-import { ApiRepository } from './api-repo'
+import { ApiClient } from '@/utils/client'
 
 type ApiKeyList = {
   data: Array<ApiKey>
@@ -20,7 +20,7 @@ export interface ApiKeyRepoInterface {
   revokeKey(key: ApiKey): Promise<void>
 }
 
-export class ApiKeyRepository extends ApiRepository implements ApiKeyRepoInterface {
+export class ApiKeyRepository extends ApiClient implements ApiKeyRepoInterface {
   async getKeys(): Promise<Array<ApiKey>> {
     const resp = await this.sendRequest(`/api/v1/keys`, 'GET')
     return (resp as ApiKeyList).data

--- a/app/src/repos/monitor-repo.ts
+++ b/app/src/repos/monitor-repo.ts
@@ -1,5 +1,5 @@
 import type { MonitorSummary, MonitorIdentity, Monitor, MonitorInformation } from '@/types/monitor'
-import { ApiRepository } from './api-repo'
+import { ApiClient } from '@/utils/client'
 
 export interface MonitorRepoInterface {
   getMonitorInfos(): Promise<Array<MonitorInformation>>
@@ -20,7 +20,7 @@ type MonitorList = {
   }
 }
 
-export class MonitorRepository extends ApiRepository implements MonitorRepoInterface {
+export class MonitorRepository extends ApiClient implements MonitorRepoInterface {
   async getMonitorInfos(): Promise<Array<MonitorInformation>> {
     const resp = await this.sendRequest(`/api/v1/monitors`, 'GET')
     return (resp as MonitorList).data

--- a/app/src/services/__tests__/alert-service.spec.ts
+++ b/app/src/services/__tests__/alert-service.spec.ts
@@ -1,0 +1,81 @@
+import { afterAll, afterEach, beforeAll, describe, it, expect } from 'vitest'
+import { HttpResponse, http } from 'msw'
+
+import type { AlertConfig } from '@/types/alert-config'
+import { AlertConfigService } from '../alert-service'
+
+import { setupTestAPI } from '@/utils/testing/test-api'
+
+describe('AlertConfigService', () => {
+  const server = setupTestAPI('foo-token')
+
+  // Start server before all tests
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+
+  // Close server after all tests
+  afterAll(() => server.close())
+
+  // Reset handlers after each test `important for test isolation`
+  afterEach(() => server.resetHandlers())
+
+  const service = new AlertConfigService(() => 'foo-token')
+  const alertConfig: AlertConfig = {
+    // Same alert config ID as utils/testing/test-api.ts
+    alert_config_id: 'eef240ae-a5b3-4971-b3c3-2603434d1ede',
+    name: 'Test Alert',
+    active: true,
+    on_late: true,
+    on_error: false,
+    monitors: [],
+    type: {
+      Slack: {
+        channel: '#alerts',
+        token: 'fake-token'
+      }
+    }
+  }
+
+  it('sends a test alert', async () => {
+    await service.sendTestAlert(alertConfig)
+
+    await expect(async () => await service.sendTestAlert(alertConfig)).not.toThrowError()
+  })
+
+  it('throws when the alert config is not found', async () => {
+    server.use(
+      http.post('/api/v1/alert-configs/eef240ae-a5b3-4971-b3c3-2603434d1ede/test', () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: 404,
+              reason: 'Not Found',
+              description: 'The requested resource could not be found.'
+            }
+          },
+          { status: 404 }
+        )
+      })
+    )
+
+    await expect(async () => await service.sendTestAlert(alertConfig)).rejects.toThrowError()
+  })
+
+  it('throws when the test alert cannot be sent', async () => {
+    server.use(
+      http.post('/api/v1/alert-configs/eef240ae-a5b3-4971-b3c3-2603434d1ede/test', () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: 500,
+              reason: 'Internal Server Error',
+              description: 'An unexpected error occurred.'
+            }
+          },
+          { status: 500 }
+        )
+      })
+    )
+
+    await expect(async () => await service.sendTestAlert(alertConfig)).rejects.toThrowError()
+  })
+})

--- a/app/src/services/alert-service.ts
+++ b/app/src/services/alert-service.ts
@@ -1,0 +1,12 @@
+import type { AlertConfig } from '@/types/alert-config'
+import { ApiClient } from '@/utils/client'
+
+export interface AlertServiceInterface {
+  sendTestAlert(alertConfig: AlertConfig): Promise<void>
+}
+
+export class AlertConfigService extends ApiClient implements AlertServiceInterface {
+  async sendTestAlert(alertConfig: AlertConfig): Promise<void> {
+    await this.sendRequest(`/api/v1/alert-configs/${alertConfig.alert_config_id}/test`, 'POST')
+  }
+}

--- a/app/src/utils/client.ts
+++ b/app/src/utils/client.ts
@@ -2,7 +2,7 @@ type ApiResponse = {
   data: unknown
 }
 
-export class ApiRepository {
+export class ApiClient {
   private readonly baseUrl = import.meta.env.VITE_API_HOST
   protected readonly getAuthToken: () => string
 

--- a/app/src/utils/testing/test-api.ts
+++ b/app/src/utils/testing/test-api.ts
@@ -503,6 +503,27 @@ export function setupTestAPI(expectedToken: string): SetupServer {
         alertConfigs = alertConfigs.filter((ac) => ac.alert_config_id !== alertConfigId)
 
         return new HttpResponse(null, { status: 200 })
+      }),
+      http.post('/api/v1/alert-configs/:alertConfigId/test', ({ request, params }) => {
+        const authErroResponse = assertAuth(request)
+        if (authErroResponse) {
+          return authErroResponse
+        }
+        const { alertConfigId } = params
+        const alertConfig = alertConfigs.find((ac) => ac.alert_config_id === alertConfigId)
+        if (!alertConfig) {
+          return HttpResponse.json(
+            {
+              error: {
+                code: 404,
+                reason: 'Not Found',
+                description: 'The requested resource could not be found.'
+              }
+            },
+            { status: 404 }
+          )
+        }
+        return HttpResponse.json({}, { status: 201 })
       })
     ]
   )


### PR DESCRIPTION
Triggering test alerts doesn't feel like a repository concern, so this instead will be done from a service.