### PR TITLE
Chore/bump node and caddy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH /usr/cron-mon/app/node_modules/.bin:$PATH
 
 RUN npm install && npm run build
 
-FROM public.ecr.aws/docker/library/caddy:2.9
+FROM public.ecr.aws/docker/library/caddy:2.10
 
 COPY ./entrypoint.sh /entrypoint.sh
 COPY --from=builder /usr/cron-mon/app/dist /srv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:23.9-slim as builder
+FROM public.ecr.aws/docker/library/node:23.9-slim AS builder
 
 WORKDIR /usr/cron-mon/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:23.9-slim AS builder
+FROM public.ecr.aws/docker/library/node:23.11-slim AS builder
 
 WORKDIR /usr/cron-mon/app
 


### PR DESCRIPTION
Bump the `node` and `caddy` images we're using to resolve some security issues.

[**`node:23.9`**](https://hub.docker.com/layers/library/node/23.9-slim/images/sha256-f2370275e0250f12e393912d4069829afab77ce8f47a43a38b495fdb18709a88)

Bumping this to [`node:23.11-slim`](https://hub.docker.com/layers/library/node/22.11-slim/images/sha256-1b01570a09b39510be11b6d8ac43258d60c68846f26dba191843da614adb226b) resolved the following security issues:

| CVE name | severity |
| --- | --- |
| `CVE-2025-0395` | high |
| `CVE-2024-56406` | low |
| `CVE-2025-31115` | low |

[**`caddy:2.9`**](https://hub.docker.com/layers/library/caddy/2.9/images/sha256-6e564e7a0425b1363d9fed33204cb9eb3d22ef1094a003ea7b5cfca82cc7d956)

Upgrading to [`caddy:2.10`](https://hub.docker.com/layers/library/node/22.11-slim/images/sha256-1b01570a09b39510be11b6d8ac43258d60c68846f26dba191843da614adb226b) resolved the following security issues:

| CVE name | severity |
| --- | --- |
| `CVE-2025-22871` | critical |
| `CVE-2025-22869` | low |
| `CVE-2025-27144` | low |
| `CVE-2024-45341` | low |
| `CVE-2024-45336` | low |
| `CVE-2025-22872` | low |
| `CVE-2025-22870` | low |
| `CVE-2025-22866` | low |

Note that 1 high-severity security issue remains in this image, [`GHSA-gmc6-fwg3-75m5`](https://scout.docker.com/vulnerabilities/id/GHSA-gmc6-fwg3-75m5?s=github&n=MimeKit&t=nuget&vr=%3E%3D3.0.0%2C%3C4.7.1&utm_source=hub&utm_medium=ExternalLink)
